### PR TITLE
Maintain boot screen visibility on page load

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1079,11 +1079,15 @@ if __name__ == "__main__":
       Crafted for 3070/4060/5090 + Pi coordination. MIT-ish vibes; license TBD.</p>
     </footer>
   </div>
-  <script>
-    window.addEventListener('load', () => {
-      const loader = document.getElementById('loading-screen');
-      if (loader) loader.style.display = 'none';
-    });
-  </script>
+    <script>
+      window.addEventListener('load', () => {
+        const loader = document.getElementById('loading-screen');
+        if (loader) {
+          setTimeout(() => {
+            loader.style.display = 'none';
+          }, 2000);
+        }
+      });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure index loading screen stays visible for a couple seconds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5242b2b04832db5110b702cbd228f